### PR TITLE
Feature/81846 - delete on destroy arguement

### DIFF
--- a/docs/resources/vmname.md
+++ b/docs/resources/vmname.md
@@ -6,10 +6,11 @@ Manages a VM name in the registry via the API. This resource allows you to creat
 
 ```hcl
 resource "vmnameregistry_vmname" "example" {
-  environment   = "dev"
-  location      = "uksouth"
-  business_unit = "engineering"
-  status        = "Deployed" # Optional, defaults to "Deployed"
+  environment       = "dev"
+  location          = "uksouth"
+  business_unit     = "engineering"
+  status            = "Deployed" # Optional, defaults to "Deployed"
+  delete_on_destroy = false      # Optional, defaults to false
 }
 
 output "vm_name" {
@@ -23,6 +24,7 @@ output "vm_name" {
 - `location` (Required) – The Azure region/location for the VM name (e.g., uksouth).
 - `business_unit` (Required) – The business unit for the VM name.
 - `status` (Optional) – The status of the VM name. Allowed values: `Deployed`, `Reserved`, `Available`. Defaults to `Deployed`.
+- `delete_on_destroy` (Optional) – If `true`, permanently delete the VM name record when the resource is destroyed. If `false` (default), mark the VM name as `Reserved` instead of deleting it.
 
 ## Attributes Exported
 

--- a/provider/resource_vmname.go
+++ b/provider/resource_vmname.go
@@ -47,6 +47,12 @@ func resourceVmName() *schema.Resource {
 				Computed:    true,
 				Description: "The generated VM name returned by the API.",
 			},
+			"delete_on_destroy": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "If true, permanently delete the VM name record. If false (default), mark as Reserved.",
+			},
 		},
 	}
 }
@@ -145,7 +151,13 @@ func resourceVmNameDelete(d *schema.ResourceData, m interface{}) error {
 	url := m.(string)
 	vmName := d.Id()
 	environment := d.Get("environment").(string)
+	deleteOnDestroy := d.Get("delete_on_destroy").(bool)
+	
+	// Add force parameter if delete_on_destroy is true
 	apiUrl := fmt.Sprintf("%s?environment=%s&rowkey=%s", url, environment, vmName)
+	if deleteOnDestroy {
+		apiUrl = fmt.Sprintf("%s&force=true", apiUrl)
+	}
 	req, err := http.NewRequest("DELETE", apiUrl, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
[Enhance resourceVmName: add delete_on_destroy attribute to control VM name deletion behavior; update delete function to support forced deletion.](https://github.com/lcp-llp/terraform-provider-vmnameregistry/pull/5/commits/043172d12a3eb07eae393da9af6839ad0cf3ed36)